### PR TITLE
feat: add zsh plugin

### DIFF
--- a/orb.plugin.zsh
+++ b/orb.plugin.zsh
@@ -1,0 +1,6 @@
+# make sure you execute this *after* asdf or other version managers are loaded
+if (( $+commands[orbctl] )); then
+  eval "$(orbctl completion zsh)"
+  compdef _orb orbctl
+  compdef _orb orb
+fi


### PR DESCRIPTION
for zinit. Allows the completion plugin to be loaded via

zinit load orbstack/orbstack
