### PR TITLE
fix(zsh plugin): update zsh completion setup to match new completion function names

### DIFF
--- a/orb.plugin.zsh
+++ b/orb.plugin.zsh
@@ -1,6 +1,6 @@
 # make sure you execute this *after* asdf or other version managers are loaded
 if (( $+commands[orbctl] )); then
   eval "$(orbctl completion zsh)"
-  compdef _orb orbctl
-  compdef _orb orb
+  compdef _orbctl orbctl
+  compdef _orbctl orb
 fi


### PR DESCRIPTION
Previously, `orbctl` completion generated a function named `_orb` that was used 
for both `orbctl` and `orb` commands. However, `orbctl` now generates its own 
completion function (`_orbctl`) while orb generates `_orb`.